### PR TITLE
Fixing json parse error

### DIFF
--- a/members.js
+++ b/members.js
@@ -3,6 +3,6 @@ const members = `
     { "name": "Daniel Granger", "random": 1.137 },
     { "name": "Hunter Parks",   "random": 49080 }, 
     { "name": "Arnav Sirigere", "random": 28461 },
-    { "name": "UnOriginalPun",  "random": 03400 } 
+    { "name": "UnOriginalPun",  "random": 3400  } 
   ]
 `;


### PR DESCRIPTION
The json.parse() gave an error because it didn't like that extra leading 0 in the random number